### PR TITLE
Allow dsn in addConnection to be of type Array or DBAL\Connection

### DIFF
--- a/lib/Config.php
+++ b/lib/Config.php
@@ -14,9 +14,9 @@ class Config implements \Serializable
     /**
      * Add database connection
      *
-     * @param string  $name   Unique name for the connection
-     * @param string  $dsn    DSN string for this connection
-     * @param boolean $defaut Use this connection as the default? The first connection added is automatically set as the default, even if this flag is false.
+     * @param string                        $name    Unique name for the connection
+     * @param DBAL\Connection|array|string  $dsn     DSN string for this connection
+     * @param boolean                       $default Use this connection as the default? The first connection added is automatically set as the default, even if this flag is false.
      *
      * @return \Doctrine\DBAL\Connection
      * @throws \Spot\Exception


### PR DESCRIPTION
Documentation on [Link](http://phpdatamapper.com/docs/database-setup/) has an example to add a connection via an array. The method doc for addConnection says that the second param must be of type string, but this is not true. Some could either pass an Array, a String, or an instance of DBAL\Connection so I updated the param type to reflect this.
I found this problem because PHPStorm gave me a notice abut this.
Also fixed a typo for the default param.