### PR TITLE
Feature/multiple db connections

### DIFF
--- a/lib/Entity.php
+++ b/lib/Entity.php
@@ -16,6 +16,7 @@ abstract class Entity implements EntityInterface, \JsonSerializable
      * @var string|null
      */
     protected static $table;
+    protected static $connection;
 
     /**
      * Datasource options
@@ -101,7 +102,7 @@ abstract class Entity implements EntityInterface, \JsonSerializable
         $fields = static::fields();
         foreach ($fields as $field => $opts) {
             if (!isset($this->_data[$field])) {
-                $this->_data[$field] = isset($opts['value']) ? $opts['value'] : (isset($opts['default']) ? $opts['default'] : null);
+                $this->_data[$field] = isset($opts['value']) ? $opts['value'] : null;
             }
         }
 
@@ -124,6 +125,15 @@ abstract class Entity implements EntityInterface, \JsonSerializable
         }
 
         return static::$table;
+    }
+
+    public static function connection($connectionName = null)
+    {
+        if (null !== $connectionName) {
+            static::$connection = $connectionName;
+        }
+
+        return static::$connection;
     }
 
     /**
@@ -537,10 +547,7 @@ abstract class Entity implements EntityInterface, \JsonSerializable
 
             // Add to relation field array
             $entityName = get_class($this);
-            if (!isset(self::$relationFields[$entityName]) || !in_array($relationName, self::$relationFields[$entityName])) {
-                if (!isset(self::$relationFields[$entityName])) {
-                    self::$relationFields[$entityName] = [];
-                }
+            if (!in_array($relationName, self::$relationFields[$entityName])) {
                 self::$relationFields[$entityName][] = $relationName;
             }
         }

--- a/lib/Entity.php
+++ b/lib/Entity.php
@@ -16,6 +16,11 @@ abstract class Entity implements EntityInterface, \JsonSerializable
      * @var string|null
      */
     protected static $table;
+
+    /**
+     * Connection name
+     * @var string|null
+     */
     protected static $connection;
 
     /**

--- a/lib/Entity.php
+++ b/lib/Entity.php
@@ -107,7 +107,7 @@ abstract class Entity implements EntityInterface, \JsonSerializable
         $fields = static::fields();
         foreach ($fields as $field => $opts) {
             if (!isset($this->_data[$field])) {
-                $this->_data[$field] = isset($opts['value']) ? $opts['value'] : null;
+                $this->_data[$field] = isset($opts['value']) ? $opts['value'] : (isset($opts['default']) ? $opts['default'] : null);
             }
         }
 
@@ -552,7 +552,10 @@ abstract class Entity implements EntityInterface, \JsonSerializable
 
             // Add to relation field array
             $entityName = get_class($this);
-            if (!in_array($relationName, self::$relationFields[$entityName])) {
+            if (!isset(self::$relationFields[$entityName]) || !in_array($relationName, self::$relationFields[$entityName])) {
+                if (!isset(self::$relationFields[$entityName])) {
+                    self::$relationFields[$entityName] = [];
+                }
                 self::$relationFields[$entityName][] = $relationName;
             }
         }

--- a/lib/Entity/Manager.php
+++ b/lib/Entity/Manager.php
@@ -104,6 +104,7 @@ class Manager
                 throw new \InvalidArgumentException("Entity must have a table defined. Please define a protected static property named 'table' on your '" . $entityName . "' entity class.");
             }
             $this->table = $entityTable;
+            $this->connection = $entityName::connection();
 
             // Table Options
             $entityTableOptions = $entityName::tableOptions();
@@ -402,6 +403,20 @@ class Manager
         }
 
         return $this->table;
+    }
+
+    /**
+     * Get name of db connection for given entity class
+     *
+     * @return string
+     */
+    public function connection()
+    {
+        if ($this->connection === null) {
+            $this->fields();
+        }
+
+        return $this->connection;
     }
 
     /**

--- a/lib/EntityInterface.php
+++ b/lib/EntityInterface.php
@@ -12,6 +12,10 @@ interface EntityInterface
      * Table name getter/setter
      */
     public static function table($tableName = null);
+
+    /**
+     * Connection name getter/setter
+     */
     public static function connection($connectionName = null);
 
     /**

--- a/lib/EntityInterface.php
+++ b/lib/EntityInterface.php
@@ -12,6 +12,7 @@ interface EntityInterface
      * Table name getter/setter
      */
     public static function table($tableName = null);
+    public static function connection($connectionName = null);
 
     /**
      * Datasource options getter/setter

--- a/lib/Mapper.php
+++ b/lib/Mapper.php
@@ -360,10 +360,11 @@ class Mapper implements MapperInterface
      * @return \Doctrine\DBAL\Connection
      * @throws \Spot\Exception
      */
-    public function connection($connectionName = null)
+    public function connection()
     {
+        $connectionName = $this->entityManager()->connection();
         // Try getting connection based on given name
-        if ($connectionName === null) {
+        if (empty($connectionName)) {
             return $this->config()->defaultConnection();
         } elseif ($connection = $this->config()->connection($connectionName)) {
             return $connection;

--- a/lib/Mapper.php
+++ b/lib/Mapper.php
@@ -356,13 +356,13 @@ class Mapper implements MapperInterface
     /**
      * Get connection to use
      *
-     * @param  string         $connectionName Named connection or entity class name
+     * @param string $connectionName Named connection or entity class name
      * @return \Doctrine\DBAL\Connection
      * @throws \Spot\Exception
      */
-    public function connection()
+    public function connection($connectionName = null)
     {
-        $connectionName = $this->entityManager()->connection();
+        $connectionName = $connectionName ?? $this->entityManager()->connection();
         // Try getting connection based on given name
         if (empty($connectionName)) {
             return $this->config()->defaultConnection();

--- a/lib/Mapper.php
+++ b/lib/Mapper.php
@@ -362,7 +362,7 @@ class Mapper implements MapperInterface
      */
     public function connection($connectionName = null)
     {
-        $connectionName = $connectionName ?? $this->entityManager()->connection();
+        $connectionName = $connectionName ? $connectionName : $this->entityManager()->connection();
         // Try getting connection based on given name
         if (empty($connectionName)) {
             return $this->config()->defaultConnection();

--- a/lib/MapperInterface.php
+++ b/lib/MapperInterface.php
@@ -176,7 +176,7 @@ interface MapperInterface
      * @return \Doctrine\DBAL\Connection
      * @throws \Spot\Exception
      */
-    public function connection($connectionName = null);
+    public function connection();
 
     /**
      * Test to see if collection is of the given type

--- a/lib/MapperInterface.php
+++ b/lib/MapperInterface.php
@@ -172,7 +172,6 @@ interface MapperInterface
     /**
      * Get connection to use
      *
-     * @param  string         $connectionName Named connection or entity class name
      * @return \Doctrine\DBAL\Connection
      * @throws \Spot\Exception
      */


### PR DESCRIPTION
Related to #49 I have a potential solution.
Default connection is implicit or can be explicitly stated in each entity:
`protected static $connection = 'db1'; \\optional`

Future implementations could alter where we set the connection param in the entityManager so we could set the connection dynamically (`$mapper->connection('mysql')->all();`) however I see the use case for this being incredibly low.

Note: The current unit tests work with only one database connection and I am not sure on the direction with creating new unit tests for multiple connections. Below are some basic examples on how I used and tested the setup. Any information on how to test this in isolation is appreciated.

```
<?php
require 'vendor/autoload.php';
date_default_timezone_set('UTC');

$cfg = new \Spot\Config();
$cfg->addConnection('db1', 'mysql://user:pass@127.0.0.1/db1');
$cfg->addConnection('db2',  'sqlite://path/to/db2.sqlite');
$cfg->addConnection('db3', 'mysql://user:pass@127.0.0.1/db3');
$spot = new \Spot\Locator($cfg);

$mapper = $spot->mapper('Entity\User'); \\default connection or set in class
$users = $mapper->all();
$changedConnection = $mapper->connection('db2')->query('select * from users limit 1');
```