### PR TITLE
Query::whereFieldSql bug when providing more than one parameter

### DIFF
--- a/lib/Query.php
+++ b/lib/Query.php
@@ -319,7 +319,7 @@ class Query implements \Countable, \IteratorAggregate, \ArrayAccess, \JsonSerial
             throw new Exception("Number of supplied parameters (" . $paramCount . ") does not match the number of provided placeholders (" . $placeholderCount . ")");
         }
 
-        $sql = preg_replace_callback('/\?/', function ($match) use ($builder, $params) {
+        $sql = preg_replace_callback('/\?/', function ($match) use ($builder, &$params) {
             $param = array_shift($params);
 
             return $builder->createPositionalParameter($param);

--- a/tests/QuerySql.php
+++ b/tests/QuerySql.php
@@ -320,6 +320,16 @@ class QuerySql extends \PHPUnit_Framework_TestCase
         $this->assertContains('IN', $posts->toSql());
     }
 
+    public function testWhereFieldSqlWithMultipleParams()
+    {
+        $mapper = test_spot_mapper('SpotTest\Entity\Post');
+        $params = [3,5];
+
+        $posts = $mapper->select()->whereFieldSql('id', 'BETWEEN ? AND ?', $params);
+
+        $this->assertCount(3, $posts);
+    }
+
     public function testQueryArrayAccess()
     {
         $mapper = test_spot_mapper('SpotTest\Entity\Post');


### PR DESCRIPTION
See PR #228. This adds tests to the fix provided by Marco. Since his forked repo is probably deleted, I've included the fix in this branch.