### PR TITLE
Fix for alias mapping bug

### DIFF
--- a/lib/Mapper.php
+++ b/lib/Mapper.php
@@ -1011,14 +1011,10 @@ class Mapper implements MapperInterface
     {
         $phpData = [];
         $fields = $entityName::fields();
-        $fieldAliasMappings = $this->entityManager()->fieldAliasMappings();
         $platform = $this->connection()->getDatabasePlatform();
+        $data = $this->resolver()->dataWithOutFieldAliasMappings($data);
         $entityData = array_intersect_key($data, $fields);
         foreach ($data as $field => $value) {
-            if ($fieldAlias = array_search($field, $fieldAliasMappings)) {
-                $field = $fieldAlias;
-            }
-
             // Field is in the Entity definitions
             if (isset($entityData[$field])) {
                 $typeHandler = Type::getType($fields[$field]['type']);

--- a/lib/Query/Resolver.php
+++ b/lib/Query/Resolver.php
@@ -193,6 +193,23 @@ class Resolver
     }
 
     /**
+     * Taken given aliased field name/value inputs and map them to their non-aliased names
+     */
+    public function dataWithOutFieldAliasMappings(array $data)
+    {
+        // have to call fields() otherwise fieldAliasMappings() would return null on the first entity
+        $this->mapper->entityManager()->fields();
+        $fieldAliasMappings = $this->mapper->entityManager()->fieldAliasMappings();
+        foreach ($fieldAliasMappings as $field => $aliasedField) {
+            if (array_key_exists($aliasedField, $data)) {
+                $data[$field] = $data[$aliasedField];
+                unset($data[$aliasedField]);
+            }
+        }
+        return $data;
+    }
+
+    /**
      * Execute provided query and return result
      *
      * @param  \Spot\Query $query SQL query to execute

--- a/tests/Entity/Legacy.php
+++ b/tests/Entity/Legacy.php
@@ -22,6 +22,8 @@ class Legacy extends Entity
             'name'         => ['type' => 'string', 'required' => true, 'column' => self::getNameFieldColumnName()],
             'number'       => ['type' => 'integer', 'required' => true, 'column' => self::getNumberFieldColumnName()],
             'date_created' => ['type' => 'datetime', 'value' => new \DateTime(), 'column' => self::getDateCreatedColumnName()],
+            'array'        => ['type' => 'array', 'required' => false],
+            'arrayAliased'=> ['type' => 'array', 'required' => false, 'column' => 'array_aliased']
         ];
     }
 

--- a/tests/FieldAlias.php
+++ b/tests/FieldAlias.php
@@ -143,4 +143,25 @@ class FieldAlias extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Spot\Relation\HasMany', $legacy->polymorphic_comments);
         $this->assertEquals(count($legacy->polymorphic_comments), 1);
     }
+
+    public function testFieldAliasMapping() {
+        $testId = 2545;
+        $testArray = ['testKey' => 'testValue'];
+
+        $legacy = new Legacy();
+        $legacy->id = $testId;
+        $legacy->name = 'Something Here';
+        $legacy->number = 5;
+        $legacy->array = $testArray;
+        $legacy->arrayAliased = $testArray;
+
+        $mapper = test_spot_mapper('SpotTest\Entity\Legacy');
+        $mapper->save($legacy);
+
+        unset($legacy);
+        $legacy = $mapper->get($testId);
+
+        $this->assertEquals($testArray, $legacy->array);
+        $this->assertEquals($testArray, $legacy->arrayAliased);
+    }
 }


### PR DESCRIPTION
> lib/Mapper.php

If we have an entity defined with field alias mapping then in the `$data` array the value will be referenced by the aliased name. After the `array_intersect_key($data, $fields)` filter it seems that the aliased column is not in the entity definition, but that is not true.

I provided tests for this bug in my first commit and after applying my patch in the second commit the tests passed successfully.

You can find more details inside the mentioned issues (#237, #145).