### PR TITLE
Implemented support for ordering by functions

### DIFF
--- a/lib/Query.php
+++ b/lib/Query.php
@@ -718,8 +718,15 @@ class Query implements \Countable, \IteratorAggregate, \ArrayAccess, \JsonSerial
         $field = trim($field);
         $function = strpos($field, '(');
         if ($function) {
-            $functionName = substr($field, 0, $function);
-            $field = substr($field, $function + 1, strlen($field) - strlen($functionName) - 2);
+            foreach ($fieldInfo as $key => $currentField) {
+                $fieldFound = strpos($field, $key);
+                if ($fieldFound) {
+                    $functionStart = substr($field, 0, $fieldFound);
+                    $functionEnd = substr($field, $fieldFound + strLen($key));
+                    $field = $key;
+                    break;
+                }
+            }
         }
 
         // Determine real field name (column alias support)
@@ -730,9 +737,9 @@ class Query implements \Countable, \IteratorAggregate, \ArrayAccess, \JsonSerial
         $field = $this->_tableName . '.' . $field;
         $field = $escaped ? $this->escapeIdentifier($field) : $field;
         
-        $result = $function ? $functionName . '(' : '';
+        $result = $function ? $functionStart : '';
         $result .= $field;
-        $result .= $function ? ')' : '';
+        $result .= $function ? $functionEnd : '';
 
         return $result;
     }

--- a/lib/Query.php
+++ b/lib/Query.php
@@ -713,6 +713,14 @@ class Query implements \Countable, \IteratorAggregate, \ArrayAccess, \JsonSerial
     public function fieldWithAlias($field, $escaped = true)
     {
         $fieldInfo = $this->_mapper->entityManager()->fields();
+        
+        // Detect function in field name
+        $field = trim($field);
+        $function = strpos($field, '(');
+        if ($function) {
+            $functionName = substr($field, 0, $function);
+            $field = substr($field, $function + 1, strlen($field) - strlen($functionName) - 2);
+        }
 
         // Determine real field name (column alias support)
         if (isset($fieldInfo[$field])) {
@@ -720,8 +728,13 @@ class Query implements \Countable, \IteratorAggregate, \ArrayAccess, \JsonSerial
         }
 
         $field = $this->_tableName . '.' . $field;
+        $field = $escaped ? $this->escapeIdentifier($field) : $field;
+        
+        $result = $function ? $functionName . '(' : '';
+        $result .= $field;
+        $result .= $function ? ')' : '';
 
-        return $escaped ? $this->escapeIdentifier($field) : $field;
+        return $result;
     }
 
     /**

--- a/tests/DriverSpecific.php
+++ b/tests/DriverSpecific.php
@@ -1,0 +1,19 @@
+<?php
+namespace SpotTest;
+
+/**
+ * @package Spot
+ */
+class DriverSpecific
+{
+    public static function getWeekFunction($mapper, $field = null) {
+        if ($mapper->connectionIs('mysql')) {
+            return "WEEK(" . $field . ")";
+        } else if ($mapper->connectionIs('pgsql')) {
+            return "EXTRACT(WEEK FROM TIMESTAMP " . $field . ")";
+        } else if ($mapper->connectionIs('sqlite')) {
+            return "STRFTIME('%W', " . $field . ")";
+        }
+        return false;
+	}
+}

--- a/tests/FieldAlias.php
+++ b/tests/FieldAlias.php
@@ -66,6 +66,14 @@ class FieldAlias extends \PHPUnit_Framework_TestCase
         $query = $mapper->where(['number' => 2])->order(['date_created' => 'ASC'])->noQuote();
         $this->assertContains("ORDER BY test_legacy." . self::$legacyTable->getDateCreatedColumnName() . " ASC", $query->toSql());
     }
+    
+    // Ordering by function
+    public function testLegacyOrderByFunction()
+    {
+        $mapper = test_spot_mapper('SpotTest\Entity\Legacy');
+        $query = $mapper->where(['number' => 2])->order(['WEEK(date_created)' => 'ASC'])->noQuote();
+        $this->assertContains("ORDER BY WEEK(test_legacy." . self::$legacyTable->getDateCreatedColumnName() . ") ASC", $query->toSql());
+    }
 
     // Grouping
     public function testLegacyGroupBy()
@@ -73,6 +81,14 @@ class FieldAlias extends \PHPUnit_Framework_TestCase
         $mapper = test_spot_mapper('SpotTest\Entity\Legacy');
         $query = $mapper->where(['name' => 'test_group'])->group(['id'])->noQuote();
         $this->assertEquals("SELECT * FROM test_legacy WHERE test_legacy." . self::$legacyTable->getNameFieldColumnName() . " = ? GROUP BY test_legacy." . self::$legacyTable->getIdFieldColumnName(), $query->toSql());
+    }
+    
+    // Grouping by function
+    public function testLegacyGroupByFunction()
+    {
+        $mapper = test_spot_mapper('SpotTest\Entity\Legacy');
+        $query = $mapper->where(['name' => 'test_group'])->group(['WEEK(date_created)'])->noQuote();
+        $this->assertEquals("SELECT * FROM test_legacy WHERE test_legacy." . self::$legacyTable->getNameFieldColumnName() . " = ? GROUP BY WEEK(test_legacy." . self::$legacyTable->getDateCreatedColumnName() . ")", $query->toSql());
     }
 
     // Insert

--- a/tests/FieldAlias.php
+++ b/tests/FieldAlias.php
@@ -71,12 +71,8 @@ class FieldAlias extends \PHPUnit_Framework_TestCase
     public function testLegacyOrderByFunction()
     {
         $mapper = test_spot_mapper('SpotTest\Entity\Legacy');
-        // Currently it works with mysql only
-        if (!$mapper->connectionIs('mysql')) {
-            $this->markTestSkipped('Not supported in Sqlite nor Postgres.');
-        }
-        $query = $mapper->where(['number' => 2])->order(['WEEK(date_created)' => 'ASC'])->noQuote();
-        $this->assertContains("ORDER BY WEEK(test_legacy." . self::$legacyTable->getDateCreatedColumnName() . ") ASC", $query->toSql());
+        $query = $mapper->where(['number' => 2])->order(['TRIM(date_created)' => 'ASC'])->noQuote();
+        $this->assertContains("ORDER BY TRIM(test_legacy." . self::$legacyTable->getDateCreatedColumnName() . ") ASC", $query->toSql());
     }
 
     // Grouping
@@ -91,12 +87,8 @@ class FieldAlias extends \PHPUnit_Framework_TestCase
     public function testLegacyGroupByFunction()
     {
         $mapper = test_spot_mapper('SpotTest\Entity\Legacy');
-        // Currently it works with mysql only
-        if (!$mapper->connectionIs('mysql')) {
-            $this->markTestSkipped('Not supported in Sqlite nor Postgres.');
-        }
-        $query = $mapper->where(['name' => 'test_group'])->group(['WEEK(date_created)'])->noQuote();
-        $this->assertEquals("SELECT * FROM test_legacy WHERE test_legacy." . self::$legacyTable->getNameFieldColumnName() . " = ? GROUP BY WEEK(test_legacy." . self::$legacyTable->getDateCreatedColumnName() . ")", $query->toSql());
+        $query = $mapper->where(['name' => 'test_group'])->group(['TRIM(date_created)'])->noQuote();
+        $this->assertEquals("SELECT * FROM test_legacy WHERE test_legacy." . self::$legacyTable->getNameFieldColumnName() . " = ? GROUP BY TRIM(test_legacy." . self::$legacyTable->getDateCreatedColumnName() . ")", $query->toSql());
     }
 
     // Insert

--- a/tests/FieldAlias.php
+++ b/tests/FieldAlias.php
@@ -74,6 +74,17 @@ class FieldAlias extends \PHPUnit_Framework_TestCase
         $query = $mapper->where(['number' => 2])->order(['TRIM(date_created)' => 'ASC'])->noQuote();
         $this->assertContains("ORDER BY TRIM(test_legacy." . self::$legacyTable->getDateCreatedColumnName() . ") ASC", $query->toSql());
     }
+    
+    // Ordering by complex function
+    public function testLegacyOrderByComplexFunction()
+    {
+        $mapper = test_spot_mapper('SpotTest\Entity\Legacy');
+        if (!DriverSpecific::getWeekFunction($mapper)) {
+            $this->markTestSkipped('This test is not supported with the current driver.');
+        }
+        $query = $mapper->where(['number' => 2])->order([DriverSpecific::getWeekFunction($mapper, 'date_created') => 'ASC'])->noQuote();
+        $this->assertContains("ORDER BY " . DriverSpecific::getWeekFunction($mapper, 'test_legacy.' . self::$legacyTable->getDateCreatedColumnName()) . " ASC", $query->toSql());
+    }
 
     // Grouping
     public function testLegacyGroupBy()

--- a/tests/FieldAlias.php
+++ b/tests/FieldAlias.php
@@ -71,6 +71,10 @@ class FieldAlias extends \PHPUnit_Framework_TestCase
     public function testLegacyOrderByFunction()
     {
         $mapper = test_spot_mapper('SpotTest\Entity\Legacy');
+        // Currently it works with mysql only
+        if (!$mapper->connectionIs('mysql')) {
+            $this->markTestSkipped('Not supported in Sqlite nor Postgres.');
+        }
         $query = $mapper->where(['number' => 2])->order(['WEEK(date_created)' => 'ASC'])->noQuote();
         $this->assertContains("ORDER BY WEEK(test_legacy." . self::$legacyTable->getDateCreatedColumnName() . ") ASC", $query->toSql());
     }
@@ -87,6 +91,10 @@ class FieldAlias extends \PHPUnit_Framework_TestCase
     public function testLegacyGroupByFunction()
     {
         $mapper = test_spot_mapper('SpotTest\Entity\Legacy');
+        // Currently it works with mysql only
+        if (!$mapper->connectionIs('mysql')) {
+            $this->markTestSkipped('Not supported in Sqlite nor Postgres.');
+        }
         $query = $mapper->where(['name' => 'test_group'])->group(['WEEK(date_created)'])->noQuote();
         $this->assertEquals("SELECT * FROM test_legacy WHERE test_legacy." . self::$legacyTable->getNameFieldColumnName() . " = ? GROUP BY WEEK(test_legacy." . self::$legacyTable->getDateCreatedColumnName() . ")", $query->toSql());
     }

--- a/tests/FieldAlias.php
+++ b/tests/FieldAlias.php
@@ -71,8 +71,8 @@ class FieldAlias extends \PHPUnit_Framework_TestCase
     public function testLegacyOrderByFunction()
     {
         $mapper = test_spot_mapper('SpotTest\Entity\Legacy');
-        $query = $mapper->where(['number' => 2])->order(['TRIM(date_created)' => 'ASC'])->noQuote();
-        $this->assertContains("ORDER BY TRIM(test_legacy." . self::$legacyTable->getDateCreatedColumnName() . ") ASC", $query->toSql());
+        $query = $mapper->where(['number' => 2])->order(['TRIM(name)' => 'ASC'])->noQuote();
+        $this->assertContains("ORDER BY TRIM(test_legacy." . self::$legacyTable->getNameFieldColumnName() . ") ASC", $query->toSql());
     }
     
     // Ordering by complex function
@@ -98,8 +98,8 @@ class FieldAlias extends \PHPUnit_Framework_TestCase
     public function testLegacyGroupByFunction()
     {
         $mapper = test_spot_mapper('SpotTest\Entity\Legacy');
-        $query = $mapper->where(['name' => 'test_group'])->group(['TRIM(date_created)'])->noQuote();
-        $this->assertEquals("SELECT * FROM test_legacy WHERE test_legacy." . self::$legacyTable->getNameFieldColumnName() . " = ? GROUP BY TRIM(test_legacy." . self::$legacyTable->getDateCreatedColumnName() . ")", $query->toSql());
+        $query = $mapper->where(['number' => 2])->group(['TRIM(name)'])->noQuote();
+        $this->assertEquals("SELECT * FROM test_legacy WHERE test_legacy." . self::$legacyTable->getNumberFieldColumnName() . " = ? GROUP BY TRIM(test_legacy." . self::$legacyTable->getNameFieldColumnName() . ")", $query->toSql());
     }
 
     // Insert

--- a/tests/QuerySql.php
+++ b/tests/QuerySql.php
@@ -191,6 +191,18 @@ class QuerySql extends \PHPUnit_Framework_TestCase
         $this->assertContains("ORDER BY TRIM(test_posts.date_created) ASC", $query->toSql());
         $this->assertEquals(count($query), 1);
     }
+    
+    // Ordering by complex function
+    public function testOrderByComplexFunction()
+    {
+        $mapper = test_spot_mapper('SpotTest\Entity\Post');
+        if (!DriverSpecific::getWeekFunction($mapper)) {
+            $this->markTestSkipped('This test is not supported with the current driver.');
+        }
+        $query = $mapper->select()->noQuote()->where(['status' => 2])->order([DriverSpecific::getWeekFunction($mapper, 'date_created') => 'ASC']);
+        $this->assertContains("ORDER BY " . DriverSpecific::getWeekFunction($mapper, 'test_posts.date_created') . " ASC", $query->toSql());
+        $this->assertEquals(count($query), 1);
+    }
 
     // Grouping
     public function testGroupBy()

--- a/tests/QuerySql.php
+++ b/tests/QuerySql.php
@@ -187,8 +187,8 @@ class QuerySql extends \PHPUnit_Framework_TestCase
     public function testOrderByFunction()
     {
         $mapper = test_spot_mapper('SpotTest\Entity\Post');
-        $query = $mapper->select()->noQuote()->where(['status' => 2])->order(['TRIM(date_created)' => 'ASC']);
-        $this->assertContains("ORDER BY TRIM(test_posts.date_created) ASC", $query->toSql());
+        $query = $mapper->select()->noQuote()->where(['status' => 2])->order(['TRIM(body)' => 'ASC']);
+        $this->assertContains("ORDER BY TRIM(test_posts.body) ASC", $query->toSql());
         $this->assertEquals(count($query), 1);
     }
     
@@ -217,8 +217,8 @@ class QuerySql extends \PHPUnit_Framework_TestCase
     public function testGroupByFunction()
     {
         $mapper = test_spot_mapper('SpotTest\Entity\Post');
-        $query = $mapper->select()->noQuote()->where(['status' => 2])->group(['TRIM(date_created)']);
-        $this->assertEquals("SELECT * FROM test_posts WHERE test_posts.status = ? GROUP BY TRIM(test_posts.date_created)", $query->toSql());
+        $query = $mapper->select()->noQuote()->where(['status' => 2])->group(['TRIM(body)']);
+        $this->assertEquals("SELECT * FROM test_posts WHERE test_posts.status = ? GROUP BY TRIM(test_posts.body)", $query->toSql());
         $this->assertEquals(count($query), 1);
     }
 

--- a/tests/QuerySql.php
+++ b/tests/QuerySql.php
@@ -182,6 +182,15 @@ class QuerySql extends \PHPUnit_Framework_TestCase
         $this->assertContains("ORDER BY test_posts.date_created ASC", $query->toSql());
         $this->assertEquals(count($query), 1);
     }
+    
+    // Ordering by function
+    public function testOrderByFunction()
+    {
+        $mapper = test_spot_mapper('SpotTest\Entity\Post');
+        $query = $mapper->select()->noQuote()->where(['status' => 2])->order(['WEEK(date_created)' => 'ASC']);
+        $this->assertContains("ORDER BY WEEK(test_posts.date_created) ASC", $query->toSql());
+        $this->assertEquals(count($query), 1);
+    }
 
     // Grouping
     public function testGroupBy()
@@ -189,6 +198,15 @@ class QuerySql extends \PHPUnit_Framework_TestCase
         $mapper = test_spot_mapper('SpotTest\Entity\Post');
         $query = $mapper->select()->noQuote()->where(['status' => 2])->group(['id']);
         $this->assertEquals("SELECT * FROM test_posts WHERE test_posts.status = ? GROUP BY test_posts.id", $query->toSql());
+        $this->assertEquals(count($query), 1);
+    }
+    
+    // Grouping by function
+    public function testGroupByFunction()
+    {
+        $mapper = test_spot_mapper('SpotTest\Entity\Post');
+        $query = $mapper->select()->noQuote()->where(['status' => 2])->group(['WEEK(date_created)']);
+        $this->assertEquals("SELECT * FROM test_posts WHERE test_posts.status = ? GROUP BY WEEK(test_posts.date_created)", $query->toSql());
         $this->assertEquals(count($query), 1);
     }
 

--- a/tests/QuerySql.php
+++ b/tests/QuerySql.php
@@ -187,6 +187,10 @@ class QuerySql extends \PHPUnit_Framework_TestCase
     public function testOrderByFunction()
     {
         $mapper = test_spot_mapper('SpotTest\Entity\Post');
+        // Currently it works with mysql only
+        if (!$mapper->connectionIs('mysql')) {
+            $this->markTestSkipped('Not supported in Sqlite nor Postgres.');
+        }
         $query = $mapper->select()->noQuote()->where(['status' => 2])->order(['WEEK(date_created)' => 'ASC']);
         $this->assertContains("ORDER BY WEEK(test_posts.date_created) ASC", $query->toSql());
         $this->assertEquals(count($query), 1);
@@ -205,6 +209,10 @@ class QuerySql extends \PHPUnit_Framework_TestCase
     public function testGroupByFunction()
     {
         $mapper = test_spot_mapper('SpotTest\Entity\Post');
+        // Currently it works with mysql only
+        if (!$mapper->connectionIs('mysql')) {
+            $this->markTestSkipped('Not supported in Sqlite nor Postgres.');
+        }
         $query = $mapper->select()->noQuote()->where(['status' => 2])->group(['WEEK(date_created)']);
         $this->assertEquals("SELECT * FROM test_posts WHERE test_posts.status = ? GROUP BY WEEK(test_posts.date_created)", $query->toSql());
         $this->assertEquals(count($query), 1);

--- a/tests/QuerySql.php
+++ b/tests/QuerySql.php
@@ -187,12 +187,8 @@ class QuerySql extends \PHPUnit_Framework_TestCase
     public function testOrderByFunction()
     {
         $mapper = test_spot_mapper('SpotTest\Entity\Post');
-        // Currently it works with mysql only
-        if (!$mapper->connectionIs('mysql')) {
-            $this->markTestSkipped('Not supported in Sqlite nor Postgres.');
-        }
-        $query = $mapper->select()->noQuote()->where(['status' => 2])->order(['WEEK(date_created)' => 'ASC']);
-        $this->assertContains("ORDER BY WEEK(test_posts.date_created) ASC", $query->toSql());
+        $query = $mapper->select()->noQuote()->where(['status' => 2])->order(['TRIM(date_created)' => 'ASC']);
+        $this->assertContains("ORDER BY TRIM(test_posts.date_created) ASC", $query->toSql());
         $this->assertEquals(count($query), 1);
     }
 
@@ -209,12 +205,8 @@ class QuerySql extends \PHPUnit_Framework_TestCase
     public function testGroupByFunction()
     {
         $mapper = test_spot_mapper('SpotTest\Entity\Post');
-        // Currently it works with mysql only
-        if (!$mapper->connectionIs('mysql')) {
-            $this->markTestSkipped('Not supported in Sqlite nor Postgres.');
-        }
-        $query = $mapper->select()->noQuote()->where(['status' => 2])->group(['WEEK(date_created)']);
-        $this->assertEquals("SELECT * FROM test_posts WHERE test_posts.status = ? GROUP BY WEEK(test_posts.date_created)", $query->toSql());
+        $query = $mapper->select()->noQuote()->where(['status' => 2])->group(['TRIM(date_created)']);
+        $this->assertEquals("SELECT * FROM test_posts WHERE test_posts.status = ? GROUP BY TRIM(test_posts.date_created)", $query->toSql());
         $this->assertEquals(count($query), 1);
     }
 


### PR DESCRIPTION
It would be really nice if you could order by a built-in (or user-defined) driver function. Currently ```count()``` and ```group()``` only works with fields specified in the entity's definition because ```fieldAliasMapping()``` appends the tableName before the fieldName. If the fieldName happens to be a function then it does not work. I implemented a simple "function detector" that works with one parameter (mysql) functions. It does not work with complex functions.

This way you can do something like this:
```php
$mapper->all()->order(['WEEK(date)' => 'ASC', 'priority' => 'DESC']);
```
It translates to this:
```mysql
ORDER BY WEEK(table.date) ASC, priority DESC
```
instead of 
```mysql
ORDER BY table.WEEK(date) ASC, priority DESC
```
This is 100% backwards compatible and it does not break the field alias support. What do you guys think?