### PR TITLE
Fix for undefined property bug caused by PR#251

### DIFF
--- a/lib/Entity/Manager.php
+++ b/lib/Entity/Manager.php
@@ -57,6 +57,12 @@ class Manager
     protected $table;
 
     /**
+     * Connection name
+     * @var string|null
+     */
+    protected $connection;
+    
+    /**
      * @var
      */
     protected $tableOptions;


### PR DESCRIPTION
```Notice: Undefined property: Spot\Entity\Manager::$connection in /vendor/vlucas/spot2/lib/Entity/Manager.php on line 415```

PHP 7.1
Latest spot2

Is it appearing just for me? Before the latest merge it was fine. @dasper?