### PR TITLE
PHP >= 7.2 generates warning "count(): Parameter must be an array or an object that implements Countable"

### DIFF
--- a/lib/Config.php
+++ b/lib/Config.php
@@ -189,7 +189,7 @@ class Config implements \Serializable
             $parsed['dbsyntax'] = $str;
         }
 
-        if ( !count( $dsn ) ) {
+        if ( empty( $dsn ) ) {
             return $parsed;
         }
 


### PR DESCRIPTION
PHP >= 7.2 generates warning "count(): Parameter must be an array or an object that implements Countable"