### PR TITLE
Added the NestedRelation

### DIFF
--- a/lib/Mapper.php
+++ b/lib/Mapper.php
@@ -2,6 +2,7 @@
 namespace Spot;
 
 use Doctrine\DBAL\Types\Type;
+use Spot\Relation\RelationAbstract;
 
 /**
  * Base DataMapper
@@ -216,6 +217,19 @@ class Mapper implements MapperInterface
 
         // Return relation object so query can be lazy-loaded
         return new Relation\BelongsTo($this, $foreignEntity, $foreignKey, $localKey, $entity->$localKey);
+    }
+
+    /**
+     * Relation: NestedRelation
+     *
+     * @param RelationAbstract $relationObject
+     * @param RelationAbstract $parentRelationObject
+     *
+     * @return Relation\NestedRelation
+     */
+    public function nestedRelation(RelationAbstract $relationObject, RelationAbstract $parentRelationObject)
+    {
+        return new Relation\NestedRelation($relationObject, $parentRelationObject);
     }
 
     /**

--- a/lib/Relation/NestedRelation.php
+++ b/lib/Relation/NestedRelation.php
@@ -1,0 +1,179 @@
+<?php
+namespace Spot\Relation;
+
+use Spot\EntityInterface;
+use Spot\Entity\Collection;
+
+/**
+ * NestedRelation
+ *
+ * Used for eager-loading multilevel relations
+ *
+ * @package Spot
+ */
+class NestedRelation extends RelationAbstract
+{
+    /**
+     * @var RelationAbstract
+     */
+    protected $relationObject;
+
+    /**
+     * @var RelationAbstract
+     */
+    protected $parentRelationObject;
+
+    /**
+     * @var string
+     */
+    protected $parentRelationName;
+
+    /**
+     * @var string
+     */
+    protected $relationName;
+
+    /*
+     * @var Collection
+     */
+    protected $relationCollection;
+
+    /**
+     * @var array
+     */
+    protected $relationCollectionReversedIdentities = [];
+
+    /**
+     * NestedRelation constructor
+     *
+     * @param RelationAbstract $relationObject
+     * @param RelationAbstract $parentRelationObject
+     */
+    public function __construct (
+        RelationAbstract $relationObject,
+        RelationAbstract $parentRelationObject
+    )
+    {
+        $this->relationObject = $relationObject;
+        $this->parentRelationObject = $parentRelationObject;
+    }
+
+    /**
+     * Set identity values from given collection
+     *
+     * @param \Spot\Entity\Collection
+     */
+    public function identityValuesFromCollection(Collection $collection)
+    {
+        // This method is not used here
+    }
+
+    /**
+     * Build query object
+     *
+     * @return \Spot\Query
+     */
+    protected function buildQuery()
+    {
+        return $this->relationObject->buildQuery();
+    }
+
+    /**
+     * Map relation results to original collection of entities
+     *
+     * @param string Relation name
+     * @param \Spot\Entity\Collection Collection of original entities to map results of query back to
+     *
+     * @return \Spot\Entity\Collection
+     *
+     * @throws \Exception
+     */
+    public function eagerLoadOnCollection($relationName, Collection $collection)
+    {
+        $relationNames = explode('.', $relationName);
+        $this->relationName = array_pop($relationNames);
+        $this->parentRelationName = array_pop($relationNames);
+
+        $this->createRelationCollection($collection);
+
+        $filledRelationCollection = $this->relationObject->eagerLoadOnCollection($this->relationName, $this->relationCollection);
+
+        if (!empty($this->relationCollectionReversedIdentities)) {
+            $result = [];
+            foreach ($filledRelationCollection as $ent) {
+                $result[$this->relationCollectionReversedIdentities[$ent->getId()]][] = $ent;
+            }
+            $filledRelationCollection = $result;
+        }
+
+        return $this->addFilledCollection($collection, $filledRelationCollection);
+    }
+
+    /**
+     * @param $collection
+     * @param $filledRelationCollection
+     *
+     * @return mixed
+     */
+    public function addFilledCollection($collection, $filledRelationCollection)
+    {
+        $parentCollection = $collection;
+        if ($this->parentRelationObject instanceof NestedRelation) {
+            $parentCollection = $this->parentRelationObject->relationCollection;
+        }
+
+        foreach($parentCollection as $entity) {
+            $entity->relation($this->parentRelationName, $filledRelationCollection[$entity->getId()]);
+        }
+
+        if ($this->parentRelationObject instanceof NestedRelation) {
+            return $this->parentRelationObject->addFilledCollection($collection, $parentCollection);
+        }
+
+        return $parentCollection;
+    }
+
+    /**
+     * @param Collection $collection
+     */
+    public function createRelationCollection(Collection $collection)
+    {
+        if ($this->parentRelationObject instanceof NestedRelation) {
+            $collection = $this->parentRelationObject->relationCollection;
+        }
+        $relationCollection = [];
+        $resultsIdentities = [];
+        foreach($collection as $entity) {
+            $relatedEntity = $entity->relation($this->parentRelationName);
+            if ($relatedEntity instanceof Collection) {
+                foreach ($relatedEntity as $childEntity) {
+                    $relationCollection[] = $childEntity;
+                    $resultsIdentities[] = $childEntity->getId();
+                    $this->relationCollectionReversedIdentities[$childEntity->getId()] = $entity->getId();
+                }
+            } else {
+                $relationCollection[$entity->getId()] = $relatedEntity;
+                $resultsIdentities[] = $relatedEntity->getId();
+            }
+        }
+        $this->relationCollection = new Collection($relationCollection, $resultsIdentities);
+        $this->relationObject->identityValuesFromCollection($this->relationCollection);
+    }
+
+
+    /**
+     * Save related entities
+     *
+     * @param EntityInterface $entity Entity to save relation from
+     * @param string $relationName Name of the relation to save
+     * @param array $options Options to pass to the mappers
+     *
+     * @return boolean
+     *
+     * @throws \Exception
+     */
+    public function save(EntityInterface $entity, $relationName, $options = [])
+    {
+        return true; // Not needed to be implemented
+    }
+}


### PR DESCRIPTION
NestedRelation can be used for eager-loading of multi-level related entities.

Usage example for Post Entity:

```
namespace Entity;

use Spot\EntityInterface as Entity;
use Spot\MapperInterface as Mapper;

class Post extends \Spot\Entity
{
    protected static $table = 'posts';

    public static function fields()
    {
        return [
            'id'           => ['type' => 'integer', 'autoincrement' => true, 'primary' => true],
            'user_id'      => ['type' => 'integer', 'required' => true],
            'title'        => ['type' => 'string', 'required' => true],
            'body'         => ['type' => 'text', 'required' => true],
            'status'       => ['type' => 'integer', 'default' => 0, 'index' => true],
            'date_created' => ['type' => 'datetime', 'value' => new \DateTime()]
        ];
    }

    public static function relations(Mapper $mapper, Entity $entity)
    {
        $userRelation = $mapper->belongsTo($entity, 'Entity\User', 'user_id');
        $profileRelation =  User::relations($mapper, $entity)['profile'];
        return [
            'user' => $userRelation,
            'user.profile' => $mapper->nestedRelation($profileRelation, $userRelation);
        ];
    }
}
```

And then we can eager load user profiles with posts:

`$posts = $posts->all()->with(['user', 'user.profile']);`


NestedRelation can be used with any relations and can be multilevel. For example:

```
$posts = $posts->all()->with([
     'user', 
     'user.profile'
     'user.profile.image',
     'comments',
     'comments.user',
     'comments.user.profile',
     'comments.user.profile.image'
]);
```