### PR TITLE
FIx memory leak in Entity

### DIFF
--- a/lib/Entity.php
+++ b/lib/Entity.php
@@ -544,6 +544,9 @@ abstract class Entity implements EntityInterface, \JsonSerializable
             if (isset($relations[$objectId][$relationName])) {
                 unset($relations[$objectId][$relationName]);
             }
+            if (isset($relations[$objectId]) && !$relations[$objectId]) {
+                unset($relations[$objectId]);
+            }
 
             return false;
         } else {


### PR DESCRIPTION
This fixes a memory leak in the Entity class.
In my case, this represented ~3kB per Entity (which has around 40 relations).
I don't think tests are needed for this PR.